### PR TITLE
Updated file with Italian translations.

### DIFF
--- a/strings/it_IT.tex
+++ b/strings/it_IT.tex
@@ -4,9 +4,9 @@
 \def\tdl@immediate{azioni successive: finire oggi}
 \def\tdl@urgent{importante: terminare entro una settimana}
 \def\tdl@backlog{arretrati: può attendere atleast una settimana}
-\def\tdl@Mo{Mo}
-\def\tdl@Tu{Tu}
-\def\tdl@We{We}
-\def\tdl@Th{Th}
-\def\tdl@Fr{Fr}
-\def\tdl@SaSu{Sa/Su}
+\def\tdl@Mo{Lun}
+\def\tdl@Tu{Mar}
+\def\tdl@We{Mer}
+\def\tdl@Th{Gio}
+\def\tdl@Fr{Ven}
+\def\tdl@SaSu{Sab/Dom}


### PR DESCRIPTION
Check the abbreviation for `Sunday`. Got both `Dom` and `Do`. PR for issue [#23](https://github.com/wamserma/tex-tdl/issues/23). 
